### PR TITLE
Exit process on uncaught exception

### DIFF
--- a/child.js
+++ b/child.js
@@ -14,5 +14,6 @@ function infanticide(child, signal, parent) {
     parent.removeListener("uncaughtException", onUncaughtException);
     console.error("Uncaught Exception\n", err.stack);
     child.kill(signal);
+    process.exit(1);
   });
 }


### PR DESCRIPTION
Okay, again I am not sure about best practices, but it seems to me like exiting after an uncaught exception is the right thing to do